### PR TITLE
Fix: Wrap RSS description in CDATA

### DIFF
--- a/themes/aifocustheme/layouts/rss.xml
+++ b/themes/aifocustheme/layouts/rss.xml
@@ -19,7 +19,7 @@
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
-      <description>{{- .Content | html -}}</description>
+      <description><![CDATA[{{- .Content | html -}}]]></description>
     </item>
     {{ end }}
   </channel>


### PR DESCRIPTION
This change wraps the content of the <description> tag in the RSS feed template (themes/aifocustheme/layouts/rss.xml) with CDATA. This ensures that raw HTML within the summary is correctly parsed by RSS readers.