### PR TITLE
Fix share buttons inconsistent height

### DIFF
--- a/themes/aifocustheme/assets/css/main.css
+++ b/themes/aifocustheme/assets/css/main.css
@@ -456,12 +456,13 @@ footer {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75em;
-  align-items: center;
+  align-items: stretch;
 }
 
 .share-button {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.5em;
   padding: 0.6em 1.2em;
   background-color: var(--background);
@@ -474,6 +475,7 @@ footer {
   cursor: pointer;
   transition: all 0.2s ease;
   border-radius: 4px;
+  box-sizing: border-box;
 }
 
 .share-button:hover {


### PR DESCRIPTION
Use align-items: stretch on the flex container so all share buttons
(mix of <a> and <button> elements) render at the same height. Added
justify-content: center and box-sizing: border-box for consistent sizing.

https://claude.ai/code/session_01CEHEgi36tV1pRWuCmrHrzf