### PR TITLE
Fix mobile viewport scaling caused by footer icons

### DIFF
--- a/themes/aifocustheme/assets/css/main.css
+++ b/themes/aifocustheme/assets/css/main.css
@@ -75,8 +75,11 @@ footer {
   text-align: center;
   ul {
     list-style: none; /* Remove default list style */
+    margin-left: 0;
     padding: 0; /* Remove default padding */
     display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
     gap: 1em;
 
     a {

--- a/themes/aifocustheme/layouts/_partials/head.html
+++ b/themes/aifocustheme/layouts/_partials/head.html
@@ -1,5 +1,5 @@
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{{ if .IsHome }}{{ site.Title }}{{ else }}{{ printf "%s | %s" .Title site.Title }}{{ end }}</title>
 <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ if .IsPage }}{{ .Summary }}{{ else }}{{ site.Params.description }}{{ end }}{{ end }}">
 <meta name="robots" content="index, follow">


### PR DESCRIPTION
## Summary
- Footer social icon list was a non-wrapping flex row of 7 items (Github, Email, RSS, Discord, X, Bluesky, Newsletter), forcing the page wider than a phone screen so mobile browsers auto-scaled the viewport down to fit.
- Added `flex-wrap: wrap` + `justify-content: center` to the footer `ul` so icons wrap onto multiple lines on narrow viewports, and reset the inherited `margin-left: 1em` from the global `ul` rule.
- Pinned the viewport meta with `initial-scale=1` so the page doesn't start out zoomed.

## Test plan
- [ ] Load any page on a phone (or DevTools narrow viewport ~375px) — page no longer renders zoomed-out / scaled down.
- [ ] Footer icons wrap onto multiple centered rows on narrow viewports.
- [ ] Footer still renders as a single row on desktop.

https://claude.ai/code/session_01175JZLo52tofikriAH9VDR

---
_Generated by [Claude Code](https://claude.ai/code/session_01175JZLo52tofikriAH9VDR)_